### PR TITLE
Fix error when uploading nested directories

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ const getFileList = (dir: string) => {
         const isDir = item.isDirectory();
         const absolutePath = path.join(dir, item.name);
         if (isDir) {
-            files = [...files, ...getFileList(path.join(absolutePath))];
+            files = [...files, ...getFileList(absolutePath)];
         } else {
             files.push(absolutePath);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,28 +26,28 @@ const S3 = new S3Client({
     endpoint: `https://${config.accountId}.r2.cloudflarestorage.com`,
     credentials: {
         accessKeyId: config.accessKeyId,
-        secretAccessKey: config.secretAccessKey
-    }
+        secretAccessKey: config.secretAccessKey,
+    },
 });
 
 const getFileList = (dir: string) => {
-  let files: string[] = []
-  const items = fs.readdirSync(dir, {
-    withFileTypes: true,
-  })
+    let files: string[] = [];
+    const items = fs.readdirSync(dir, {
+        withFileTypes: true,
+    });
 
-  for (const item of items) {
-    const isDir = item.isDirectory()
-    const absolutePath = path.join(dir, item.name)
-    if (isDir) {
-      files = [...files, ...getFileList(path.join(absolutePath))]
-    } else {
-      files.push(absolutePath)
+    for (const item of items) {
+        const isDir = item.isDirectory();
+        const absolutePath = path.join(dir, item.name);
+        if (isDir) {
+            files = [...files, ...getFileList(path.join(absolutePath))];
+        } else {
+            files.push(absolutePath);
+        }
     }
-  }
 
-  return files
-}
+    return files;
+};
 
 const run = async (config: R2Config) => {
     const map = new Map<string, PutObjectCommandOutput>();


### PR DESCRIPTION
Thanks for making this action @elementemerald!

I ran into an issue where I had some files at path `fonts/gotham/{...some font files}` however these couldn't be uploaded due to the `getFileList` function joining the path incorrectly.

Essentially the issue doesn't happen on the first pass because `sourceDir` includes a trailing slash (ex `dist/`), but then for any nested folders there is no trailing slash in the file names thus the directory names are joined without a `/` in the middle:
```
getFileList('dist/') -> ['fonts']
isDir = true
...
getFileList('dist/' + 'fonts') -> ['gotham']
isDir = true
...
getFileList('fonts' + 'gotham') -> Throws an error due to missing file at `fontsgotham` (real path should be `dist/fonts/gotham`)
```

To fix this, I added `path` and used `path.join` rather than the template string concatenation. I didn't commit the build output after these changes, but am happy to build it locally and include the `dist` output along with these changes if so desired.